### PR TITLE
add extra escapes for jinja2 templating, export TMPDIR to SLURM, trap…

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,6 @@
 	"profile_name": "mpi-ie-slurm",
 	"email": "$USER@ie-freiburg.mpg.de",
 	"default_partition": "bioinfo",
-	"default_tempdir": "/data/extended/$USER",
+	"default_tmpdir": "/data/extended/$USER",
 	"conda_prefix": "/localenv/$USER/anaconda/snakemake-envs"
 }

--- a/test/test_tmpdir/Snakefile
+++ b/test/test_tmpdir/Snakefile
@@ -1,3 +1,3 @@
 rule foobar:
     output: "out.txt"
-    shell: "echo $TMPDIR > {output}"
+    shell: "echo $TMPDIR > $TMPDIR/test.txt; sleep 120; echo $TMPDIR > {output}"

--- a/{{ cookiecutter.profile_name }}/config.yaml
+++ b/{{ cookiecutter.profile_name }}/config.yaml
@@ -1,17 +1,14 @@
 default-resources:
   - partition={{ cookiecutter.default_partition }}
-  #- tmpdir='{{ cookiecutter.default_tempdir }}'
+  #- tmpdir='{{ cookiecutter.default_tmpdir }}' # don't set tmpdir so snakemake uses system default
   - mem_mb=2400
   - disk_mb=2400
   - logdir=logs
   - mail_type=FAIL
   - mail_user={{ cookiecutter.email }}
 cluster:
-  mkdir -p /scratch/local/$USER;
-  scratch=$(mktemp -p /scratch/local/$USER -d -t tmp.XXXXXXXXXXXXXXXX);
-  export TMPDIR=$scratch;
-  export TEMP=$scratch;
-  export TMP=$scratch;
+  export TMPDIR={{ cookiecutter.default_tmpdir }};
+  mkdir -p $TMPDIR;
   mkdir -p {{ cookiecutter.conda_prefix }};
   module load slurm &&
   mkdir -p {resources.logdir}/cluster/`date +"%F"`/{rule} &&
@@ -26,6 +23,7 @@ cluster:
     --parsable
     --mail-user={resources.mail_user}
     --mail-type={resources.mail_type}
+    --export=TMPDIR
 restart-times: 1
 max-jobs-per-second: 10
 max-status-checks-per-second: 1
@@ -47,7 +45,7 @@ jobscript: slurm-jobscript.sh
 # additional options that might be useful for individual workflows
 
 # set a shadow directory for jobs that create lots of temporary files
-shadow-prefix: {{ cookiecutter.default_tempdir }}/shadow
+shadow-prefix: {{ cookiecutter.default_tmpdir }}/shadow
 
 # set rule-specific threads
 # set-threads:

--- a/{{ cookiecutter.profile_name }}/slurm-jobscript.sh
+++ b/{{ cookiecutter.profile_name }}/slurm-jobscript.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-function cleanup {{ rm -rf $TMPDIR; }} 
-trap cleanup SIGTERM SIGKILL SIGUSR2
+
+scratch=$(mktemp -p {{ cookiecutter.default_tmpdir }} -d -t tmp.XXXXXXXXXXXXXXXX);
+export TMPDIR=$scratch;
+export TEMP=$scratch;
+export TMP=$scratch;
+function cleanup {% raw %}{{ rm -rf $TMPDIR; }}{% endraw %}
+trap cleanup EXIT SIGTERM SIGKILL SIGUSR2
 {exec_job}
-cleanup


### PR DESCRIPTION
… EXIT instead of manually executing cleanup, modify test